### PR TITLE
feat: VehicleState model, formatters & dashboard panels

### DIFF
--- a/odb_tui/app.py
+++ b/odb_tui/app.py
@@ -5,7 +5,21 @@ from textual.binding import Binding
 from textual.widgets import Footer, Header, Static
 
 from odb_tui.controllers.app_controller import AppController
+from odb_tui.models.vehicle import VehicleState
+from odb_tui.views.panels.diag import build_diag_panel
+from odb_tui.views.panels.egr import build_egr_panel
+from odb_tui.views.panels.engine import build_engine_panel
+from odb_tui.views.panels.errors import build_errors_panel
 from odb_tui.views.panels.pids import build_pids_panel
+from odb_tui.views.panels.turbo import build_turbo_panel
+
+PANEL_BUILDERS = {
+    "engine": build_engine_panel,
+    "turbo": build_turbo_panel,
+    "egr": build_egr_panel,
+    "diag": build_diag_panel,
+    "errors": build_errors_panel,
+}
 
 
 class OBDReaderApp(App[None]):
@@ -14,42 +28,67 @@ class OBDReaderApp(App[None]):
     CSS = """
     Screen { background: black; color: green; }
     #status-bar { height: 1; text-align: right; color: green; }
+    #dashboard { display: block; }
     #pids-panel { display: none; }
+    .show-pids #dashboard { display: none; }
     .show-pids #pids-panel { display: block; }
     """
 
     BINDINGS = [
         Binding("c", "connect", "Connect"),
         Binding("d", "disconnect", "Disconnect"),
+        Binding("1", "panel('engine')", "Engine"),
+        Binding("2", "panel('turbo')", "Turbo"),
+        Binding("3", "panel('egr')", "EGR"),
+        Binding("4", "panel('diag')", "Diag"),
+        Binding("5", "panel('errors')", "Errors"),
         Binding("p", "toggle_pids", "PIDs"),
         Binding("q", "quit", "Quit"),
     ]
 
     def compose(self) -> ComposeResult:
-        """Build the widget tree: header, main content, pids panel, status bar, footer."""
+        """Build the widget tree: header, dashboard, pids panel, status bar, footer."""
         yield Header(show_clock=True)
-        yield Static("OBD-II Reader", id="main")
+        yield Static("", id="dashboard")
         yield Static("", id="pids-panel")
         self.status_bar = Static("DISCONNECTED  |  -  |  -:-", id="status-bar")
         yield self.status_bar
         yield Footer()
 
     async def on_mount(self) -> None:
-        """Initialize the controller."""
+        """Initialize the controller and default panel."""
         self.ctrl = AppController()
+        self._current_panel = "engine"
+        self._state = VehicleState()
+        self._refresh_dashboard()
 
     def _refresh_status(self) -> None:
         self.status_bar.update(f"{self.ctrl.status}  |  {self.ctrl.port}  |  {self.ctrl.vid}:{self.ctrl.pid}")
+
+    def _refresh_dashboard(self) -> None:
+        self._state.connection_status = self.ctrl.status
+        builder = PANEL_BUILDERS.get(self._current_panel, build_engine_panel)
+        dashboard = self.query_one("#dashboard", Static)
+        dashboard.update(builder(self._state))
 
     async def action_connect(self) -> None:
         """Handle 'c' key: connect to the OBD adapter."""
         self.ctrl.connect()
         self._refresh_status()
+        self._refresh_dashboard()
 
     async def action_disconnect(self) -> None:
         """Handle 'd' key: disconnect from the OBD adapter."""
         self.ctrl.disconnect()
+        self._state = VehicleState()
         self._refresh_status()
+        self._refresh_dashboard()
+
+    async def action_panel(self, name: str) -> None:
+        """Handle 1-5 keys: switch active dashboard panel."""
+        self.screen.remove_class("show-pids")
+        self._current_panel = name
+        self._refresh_dashboard()
 
     async def action_toggle_pids(self) -> None:
         """Handle 'p' key: toggle the supported PIDs panel."""

--- a/odb_tui/models/vehicle.py
+++ b/odb_tui/models/vehicle.py
@@ -1,0 +1,82 @@
+"""Vehicle state model for standard OBD-II sensor data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class VehicleState:
+    """Snapshot of all standard OBD-II sensor readings.
+
+    All fields default to None — a None value means the command
+    is not supported or has not been read yet.
+    """
+
+    # Engine
+    rpm: float | None = None
+    engine_load: float | None = None
+    abs_load: float | None = None
+    coolant_temp: float | None = None
+    oil_temp: float | None = None
+    intake_temp: float | None = None
+    ambient_temp: float | None = None
+    maf: float | None = None
+    voltage: float | None = None
+    timing: float | None = None
+    run_time: float | None = None
+
+    # Fuel
+    fuel_rail: float | None = None
+    fuel_rate: float | None = None
+    fuel_level: float | None = None
+    fuel_inject: float | None = None
+    equiv_ratio: float | None = None
+    short_ft1: float | None = None
+    long_ft1: float | None = None
+
+    # Turbo / Air
+    intake_press: float | None = None
+    baro: float | None = None
+    throttle: float | None = None
+    throttle_b: float | None = None
+    throttle_act: float | None = None
+    accel_d: float | None = None
+    accel_e: float | None = None
+    rel_accel: float | None = None
+
+    # O2
+    o2_sensors: Any | None = None
+    o2_s1_wr: float | None = None
+    o2_s2_wr: float | None = None
+
+    # EGR
+    egr_cmd: float | None = None
+    egr_err: float | None = None
+
+    # Speed
+    speed: float | None = None
+
+    # Computed
+    net_boost: float | None = None
+
+    # Diagnostics
+    status_raw: Any | None = None
+    obd_comp: Any | None = None
+    fuel_type: Any | None = None
+    fuel_status: Any | None = None
+    dist_mil: float | None = None
+    run_time_mil: float | None = None
+    warmups: float | None = None
+    dist_dtc: float | None = None
+    time_dtc: float | None = None
+    cal_id: Any | None = None
+    cvn: Any | None = None
+
+    # DTCs
+    dtc_list: list[tuple[str, str]] = field(default_factory=list)
+    current_dtc_list: list[tuple[str, str]] = field(default_factory=list)
+
+    # Connection info
+    connection_status: str = "DISCONNECTED"

--- a/odb_tui/views/formatters.py
+++ b/odb_tui/views/formatters.py
@@ -1,0 +1,50 @@
+"""Formatting utilities for panel display."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+def fmt(v: float | None) -> str:
+    """Format float with 1 decimal, or '--' if None."""
+    return f"{v:>8.1f}" if v is not None else "      --"
+
+
+def fmti(v: int | float | None) -> str:
+    """Format as integer, or '--' if None."""
+    return f"{int(v):>8d}" if v is not None else "      --"
+
+
+def fmt2(v: float | None) -> str:
+    """Format float with 2 decimals, or '--' if None."""
+    return f"{v:>8.2f}" if v is not None else "      --"
+
+
+def fmt_time(secs: float | None) -> str:
+    """Format seconds as HH:MM:SS, or '--' if None."""
+    if secs is None:
+        return "      --"
+    s = int(secs)
+    return f"{s // 3600:02d}:{(s % 3600) // 60:02d}:{s % 60:02d}"
+
+
+def fmt_str(v: Any | None) -> str:
+    """Format as string, or '--' if None."""
+    return str(v) if v is not None else "--"
+
+
+def add_if(
+    lines: list[str],
+    label: str,
+    val: Any | None,
+    fmt_fn: Callable[..., str] = fmt,
+    bar_fn: Callable[..., str] | None = None,
+    bar_max: float = 100,
+) -> None:
+    """Append a formatted line only if val is not None."""
+    if val is None:
+        return
+    line = f"  {label:<18} {fmt_fn(val)}"
+    if bar_fn is not None:
+        line += f"  {bar_fn(val, bar_max)}"
+    lines.append(line)

--- a/odb_tui/views/panels/diag.py
+++ b/odb_tui/views/panels/diag.py
@@ -1,0 +1,74 @@
+"""Diagnostics dashboard panel builder."""
+
+from __future__ import annotations
+
+from odb_tui.models.vehicle import VehicleState
+from odb_tui.views.formatters import add_if, fmt, fmt_str, fmt_time, fmti
+
+
+def build_diag_panel(state: VehicleState) -> str:
+    """Build the diagnostics panel displaying MIL, DTCs, compliance, and counters."""
+    lines: list[str] = ["DIAGNOSTICS"]
+    lines.append("─" * 60)
+
+    # Status (MIL, DTC count, ignition type)
+    mil_str = "--"
+    dtc_count_str = "--"
+    ign_str = "--"
+    if state.status_raw is not None:
+        try:
+            mil_str = "ON" if state.status_raw.MIL else "OFF"
+            dtc_count_str = str(state.status_raw.DTC_count)
+            ign_str = str(state.status_raw.ignition_type)
+        except (AttributeError, TypeError):
+            pass
+    lines.append(f"  {'MIL':<18} {mil_str:>8}")
+    lines.append(f"  {'DTC COUNT':<18} {dtc_count_str:>8}")
+    lines.append(f"  {'IGNITION':<18} {ign_str:>8}")
+
+    # OBD info
+    if state.obd_comp is not None:
+        lines.append(f"  {'OBD STANDARD':<18} {fmt_str(state.obd_comp)}")
+    if state.fuel_type is not None:
+        lines.append(f"  {'FUEL TYPE':<18} {fmt_str(state.fuel_type)}")
+    if state.fuel_status is not None:
+        lines.append(f"  {'FUEL STATUS':<18} {fmt_str(state.fuel_status)}")
+
+    # Counters
+    counters = [state.dist_mil, state.run_time_mil, state.warmups, state.dist_dtc, state.time_dtc]
+    if any(c is not None for c in counters):
+        lines.append("")
+        lines.append("COUNTERS")
+        lines.append("─" * 60)
+        add_if(lines, "DIST MIL km", state.dist_mil, fmti)
+        add_if(lines, "TIME MIL", state.run_time_mil, fmt_time)
+        add_if(lines, "WARMUPS", state.warmups, fmti)
+        add_if(lines, "DIST DTC km", state.dist_dtc, fmti)
+        add_if(lines, "TIME DTC min", state.time_dtc, fmt)
+
+    # Calibration
+    if state.cal_id is not None or state.cvn is not None:
+        lines.append("")
+        lines.append("CALIBRATION")
+        lines.append("─" * 60)
+        if state.cal_id is not None:
+            lines.append(f"  {'CAL ID':<18} {fmt_str(state.cal_id)}")
+        if state.cvn is not None:
+            lines.append(f"  {'CVN':<18} {fmt_str(state.cvn)}")
+
+    # DTCs
+    if state.dtc_list:
+        lines.append("")
+        lines.append("STORED DTCs")
+        lines.append("─" * 60)
+        for code, desc in state.dtc_list:
+            lines.append(f"  {code}  {desc}")
+
+    if state.current_dtc_list:
+        lines.append("")
+        lines.append("CURRENT DTCs")
+        lines.append("─" * 60)
+        for code, desc in state.current_dtc_list:
+            lines.append(f"  {code}  {desc}")
+
+    return "\n".join(lines)

--- a/odb_tui/views/panels/egr.py
+++ b/odb_tui/views/panels/egr.py
@@ -1,0 +1,30 @@
+"""EGR dashboard panel builder."""
+
+from __future__ import annotations
+
+from odb_tui.models.vehicle import VehicleState
+from odb_tui.views.formatters import add_if, fmt
+from odb_tui.views.widgets import bar
+
+
+def build_egr_panel(state: VehicleState) -> str:
+    """Build the EGR panel displaying commanded EGR and error interpretation."""
+    lines: list[str] = ["EGR"]
+    lines.append("─" * 60)
+
+    if state.egr_cmd is None and state.egr_err is None:
+        lines.append("  No EGR data available")
+        return "\n".join(lines)
+
+    add_if(lines, "COMMANDED %", state.egr_cmd, fmt, bar, 100)
+
+    if state.egr_err is not None:
+        if state.egr_err < 0:
+            interpretation = f"({abs(state.egr_err):.1f}% below commanded)"
+        elif state.egr_err > 0:
+            interpretation = f"({state.egr_err:.1f}% above commanded)"
+        else:
+            interpretation = "(perfect)"
+        lines.append(f"  {'ERROR %':<18} {fmt(state.egr_err)}  {interpretation}")
+
+    return "\n".join(lines)

--- a/odb_tui/views/panels/engine.py
+++ b/odb_tui/views/panels/engine.py
@@ -1,0 +1,61 @@
+"""Engine dashboard panel builder."""
+
+from __future__ import annotations
+
+from odb_tui.models.vehicle import VehicleState
+from odb_tui.views.formatters import add_if, fmt, fmt2, fmt_str, fmt_time, fmti
+from odb_tui.views.widgets import bar
+
+
+def build_engine_panel(state: VehicleState) -> str:
+    """Build the engine panel displaying RPM, load, temps, fuel, and O2 data."""
+    lines: list[str] = ["ENGINE"]
+    lines.append("─" * 60)
+
+    add_if(lines, "RPM", state.rpm, fmti, bar, 7000)
+    add_if(lines, "LOAD %", state.engine_load, fmt, bar, 100)
+    add_if(lines, "ABS LOAD %", state.abs_load, fmt, bar, 100)
+    add_if(lines, "TIMING °", state.timing, fmt)
+    add_if(lines, "RUN TIME", state.run_time, fmt_time)
+
+    # Temperatures
+    temps = [state.coolant_temp, state.oil_temp, state.intake_temp, state.ambient_temp]
+    if any(t is not None for t in temps):
+        lines.append("")
+        lines.append("TEMPERATURES")
+        lines.append("─" * 60)
+        add_if(lines, "COOLANT °C", state.coolant_temp, fmt, bar, 130)
+        add_if(lines, "OIL °C", state.oil_temp, fmt, bar, 150)
+        add_if(lines, "INTAKE °C", state.intake_temp, fmt, bar, 80)
+        add_if(lines, "AMBIENT °C", state.ambient_temp, fmt)
+
+    # Fuel
+    fuels = [state.fuel_rail, state.fuel_rate, state.fuel_level, state.fuel_inject,
+             state.equiv_ratio, state.short_ft1, state.long_ft1]
+    if any(f is not None for f in fuels):
+        lines.append("")
+        lines.append("FUEL")
+        lines.append("─" * 60)
+        add_if(lines, "RAIL kPa", state.fuel_rail, fmt)
+        add_if(lines, "RATE L/h", state.fuel_rate, fmt)
+        add_if(lines, "LEVEL %", state.fuel_level, fmt, bar, 100)
+        add_if(lines, "INJECT °", state.fuel_inject, fmt)
+        add_if(lines, "EQUIV RATIO", state.equiv_ratio, fmt2)
+        add_if(lines, "SHORT FT1 %", state.short_ft1, fmt)
+        add_if(lines, "LONG FT1 %", state.long_ft1, fmt)
+
+    # MAF / Voltage
+    add_if(lines, "MAF g/s", state.maf, fmt)
+    add_if(lines, "VOLTAGE V", state.voltage, fmt)
+
+    # O2
+    if state.o2_sensors is not None or state.o2_s1_wr is not None or state.o2_s2_wr is not None:
+        lines.append("")
+        lines.append("O2 SENSORS")
+        lines.append("─" * 60)
+        if state.o2_sensors is not None:
+            lines.append(f"  SENSORS          {fmt_str(state.o2_sensors)}")
+        add_if(lines, "S1 LAMBDA", state.o2_s1_wr, fmt2)
+        add_if(lines, "S2 LAMBDA", state.o2_s2_wr, fmt2)
+
+    return "\n".join(lines)

--- a/odb_tui/views/panels/errors.py
+++ b/odb_tui/views/panels/errors.py
@@ -1,0 +1,25 @@
+"""Errors dashboard panel builder."""
+
+from __future__ import annotations
+
+from odb_tui.models.vehicle import VehicleState
+
+
+def build_errors_panel(state: VehicleState) -> str:
+    """Build the errors panel displaying active DTCs."""
+    lines: list[str] = ["ERRORS"]
+    lines.append("─" * 60)
+
+    if state.connection_status in ("DISCONNECTED", "NO DEVICE", "FAILED"):
+        lines.append("  --")
+        return "\n".join(lines)
+
+    if state.dtc_list:
+        for code, desc in state.dtc_list:
+            lines.append(f"  {code}")
+            lines.append(f"  {desc}")
+            lines.append("")
+    else:
+        lines.append("  No errors")
+
+    return "\n".join(lines)

--- a/odb_tui/views/panels/turbo.py
+++ b/odb_tui/views/panels/turbo.py
@@ -1,0 +1,42 @@
+"""Turbo/Air dashboard panel builder."""
+
+from __future__ import annotations
+
+from odb_tui.models.vehicle import VehicleState
+from odb_tui.views.formatters import add_if, fmt
+from odb_tui.views.widgets import bar
+
+
+def build_turbo_panel(state: VehicleState) -> str:
+    """Build the turbo panel displaying pressure, boost, throttle, and accelerator data."""
+    lines: list[str] = ["TURBO / AIR"]
+    lines.append("─" * 60)
+
+    add_if(lines, "INTAKE kPa", state.intake_press, fmt, bar, 300)
+    add_if(lines, "BARO kPa", state.baro, fmt)
+
+    if state.net_boost is not None:
+        boost_bar = bar(state.net_boost, 200) if state.net_boost > 0 else ""
+        lines.append(f"  {'NET BOOST kPa':<18} {fmt(state.net_boost)}  {boost_bar}")
+
+    # Throttle
+    throttles = [state.throttle, state.throttle_b, state.throttle_act]
+    if any(t is not None for t in throttles):
+        lines.append("")
+        lines.append("THROTTLE")
+        lines.append("─" * 60)
+        add_if(lines, "POSITION %", state.throttle, fmt, bar, 100)
+        add_if(lines, "POSITION B %", state.throttle_b, fmt, bar, 100)
+        add_if(lines, "ACTUATOR %", state.throttle_act, fmt, bar, 100)
+
+    # Accelerator
+    accels = [state.accel_d, state.accel_e, state.rel_accel]
+    if any(a is not None for a in accels):
+        lines.append("")
+        lines.append("ACCELERATOR")
+        lines.append("─" * 60)
+        add_if(lines, "POSITION D %", state.accel_d, fmt, bar, 100)
+        add_if(lines, "POSITION E %", state.accel_e, fmt, bar, 100)
+        add_if(lines, "RELATIVE %", state.rel_accel, fmt, bar, 100)
+
+    return "\n".join(lines)

--- a/odb_tui/views/widgets.py
+++ b/odb_tui/views/widgets.py
@@ -1,0 +1,12 @@
+"""Text-based widgets for panel display."""
+
+from __future__ import annotations
+
+
+def bar(value: float | None, max_value: float, width: int = 28) -> str:
+    """Render a text gauge bar using block characters."""
+    if value is None or max_value <= 0:
+        return "░" * width
+    ratio = max(0.0, min(1.0, value / max_value))
+    filled = int(ratio * width)
+    return "█" * filled + "░" * (width - filled)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,0 +1,64 @@
+from odb_tui.views.formatters import add_if, fmt, fmt2, fmt_str, fmt_time, fmti
+from odb_tui.views.widgets import bar
+
+
+def test_fmt_value():
+    assert fmt(123.456) == "   123.5"
+
+
+def test_fmt_none():
+    assert fmt(None) == "      --"
+
+
+def test_fmti_value():
+    assert fmti(3000) == "    3000"
+
+
+def test_fmti_none():
+    assert fmti(None) == "      --"
+
+
+def test_fmt2_value():
+    assert fmt2(1.005) == "    1.00" or fmt2(1.005) == "    1.01"
+
+
+def test_fmt_time_value():
+    assert fmt_time(3661.0) == "01:01:01"
+
+
+def test_fmt_time_none():
+    assert fmt_time(None) == "      --"
+
+
+def test_fmt_str_value():
+    assert fmt_str("hello") == "hello"
+
+
+def test_fmt_str_none():
+    assert fmt_str(None) == "--"
+
+
+def test_add_if_with_value():
+    lines: list[str] = []
+    add_if(lines, "RPM", 3000.0, fmti)
+    assert len(lines) == 1
+    assert "RPM" in lines[0]
+    assert "3000" in lines[0]
+
+
+def test_add_if_with_none():
+    lines: list[str] = []
+    add_if(lines, "RPM", None, fmti)
+    assert len(lines) == 0
+
+
+def test_bar_value():
+    result = bar(50.0, 100.0, width=10)
+    assert "█" in result
+    assert "░" in result
+    assert len(result) == 10
+
+
+def test_bar_none():
+    result = bar(None, 100.0, width=10)
+    assert result == "░" * 10

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -1,0 +1,79 @@
+from odb_tui.models.vehicle import VehicleState
+from odb_tui.views.panels.diag import build_diag_panel
+from odb_tui.views.panels.egr import build_egr_panel
+from odb_tui.views.panels.engine import build_engine_panel
+from odb_tui.views.panels.errors import build_errors_panel
+from odb_tui.views.panels.turbo import build_turbo_panel
+
+
+def test_engine_panel_empty_state():
+    result = build_engine_panel(VehicleState())
+    assert "ENGINE" in result
+
+
+def test_engine_panel_with_data():
+    state = VehicleState(rpm=3000.0, coolant_temp=90.0, fuel_level=75.0)
+    result = build_engine_panel(state)
+    assert "3000" in result
+    assert "COOLANT" in result
+    assert "LEVEL" in result
+
+
+def test_turbo_panel_empty_state():
+    result = build_turbo_panel(VehicleState())
+    assert "TURBO" in result
+
+
+def test_turbo_panel_with_boost():
+    state = VehicleState(intake_press=200.0, baro=101.0, net_boost=99.0)
+    result = build_turbo_panel(state)
+    assert "INTAKE" in result
+    assert "NET BOOST" in result
+
+
+def test_egr_panel_empty_state():
+    result = build_egr_panel(VehicleState())
+    assert "EGR" in result
+    assert "No EGR data" in result
+
+
+def test_egr_panel_with_data():
+    state = VehicleState(egr_cmd=25.0, egr_err=-3.5)
+    result = build_egr_panel(state)
+    assert "COMMANDED" in result
+    assert "3.5% below" in result
+
+
+def test_diag_panel_empty_state():
+    result = build_diag_panel(VehicleState())
+    assert "DIAGNOSTICS" in result
+    assert "MIL" in result
+
+
+def test_diag_panel_with_dtcs():
+    state = VehicleState(dtc_list=[("P0420", "Catalyst efficiency below threshold")])
+    result = build_diag_panel(state)
+    assert "P0420" in result
+    assert "Catalyst" in result
+
+
+def test_errors_panel_not_connected():
+    state = VehicleState(connection_status="DISCONNECTED")
+    result = build_errors_panel(state)
+    assert "--" in result
+
+
+def test_errors_panel_no_errors():
+    state = VehicleState(connection_status="CONNECTED")
+    result = build_errors_panel(state)
+    assert "No errors" in result
+
+
+def test_errors_panel_with_dtcs():
+    state = VehicleState(
+        connection_status="CONNECTED",
+        dtc_list=[("P0300", "Random misfire detected")],
+    )
+    result = build_errors_panel(state)
+    assert "P0300" in result
+    assert "misfire" in result

--- a/tests/test_vehicle_state.py
+++ b/tests/test_vehicle_state.py
@@ -1,0 +1,25 @@
+from odb_tui.models.vehicle import VehicleState
+
+
+def test_vehicle_state_defaults():
+    state = VehicleState()
+    assert state.rpm is None
+    assert state.speed is None
+    assert state.coolant_temp is None
+    assert state.engine_load is None
+    assert state.net_boost is None
+    assert state.status_raw is None
+    assert state.connection_status == "DISCONNECTED"
+
+
+def test_vehicle_state_dtc_lists_default():
+    state = VehicleState()
+    assert state.dtc_list == []
+    assert state.current_dtc_list == []
+
+
+def test_vehicle_state_with_values():
+    state = VehicleState(rpm=3000.0, speed=120.0, coolant_temp=90.0)
+    assert state.rpm == 3000.0
+    assert state.speed == 120.0
+    assert state.coolant_temp == 90.0


### PR DESCRIPTION
## Summary

Add VehicleState data model for standard OBD sensor data, formatting utilities, and 5 dashboard panels with conditional display based on available data. Keybindings 1-5 switch between panels.

## Related issue

Closes #5

## Models

- `odb_tui/models/vehicle.py` — VehicleState dataclass (standard OBD fields, all None by default)

## Services

None

## Controllers

None (app.py updated directly for panel switching)

## Views

- `odb_tui/views/formatters.py` — fmt, fmti, fmt2, fmt_time, fmt_str, add_if
- `odb_tui/views/widgets.py` — bar() text gauge
- `odb_tui/views/panels/engine.py` — Engine panel (RPM, load, temps, fuel, O2)
- `odb_tui/views/panels/turbo.py` — Turbo/Air panel (pressure, boost, throttle)
- `odb_tui/views/panels/egr.py` — EGR panel (commanded, error interpretation)
- `odb_tui/views/panels/diag.py` — Diagnostics panel (MIL, DTCs, counters, calibration)
- `odb_tui/views/panels/errors.py` — Errors panel (DTC list with connection gate)
- `odb_tui/app.py` — keybindings 1-5 for panels, dashboard widget

## Tests

- [x] test_vehicle_state_defaults — all fields None by default
- [x] test_vehicle_state_dtc_lists_default — DTC lists empty by default
- [x] test_vehicle_state_with_values — creation with values
- [x] test_fmt_value — float formatting
- [x] test_fmt_none — returns "--"
- [x] test_fmti_value — integer formatting
- [x] test_fmti_none — returns "--"
- [x] test_fmt2_value — 2 decimal formatting
- [x] test_fmt_time_value — HH:MM:SS formatting
- [x] test_fmt_time_none — returns "--"
- [x] test_fmt_str_value — string conversion
- [x] test_fmt_str_none — returns "--"
- [x] test_add_if_with_value — appends line
- [x] test_add_if_with_none — skips line
- [x] test_bar_value — proportional bar
- [x] test_bar_none — empty bar
- [x] test_engine_panel_empty_state — no crash on empty state
- [x] test_engine_panel_with_data — values displayed
- [x] test_turbo_panel_empty_state — no crash
- [x] test_turbo_panel_with_boost — net boost displayed
- [x] test_egr_panel_empty_state — no data message
- [x] test_egr_panel_with_data — EGR with interpretation
- [x] test_diag_panel_empty_state — no crash
- [x] test_diag_panel_with_dtcs — DTCs listed
- [x] test_errors_panel_not_connected — shows "--"
- [x] test_errors_panel_no_errors — shows "No errors"
- [x] test_errors_panel_with_dtcs — DTCs displayed

## Dependencies

None

## Checklist

- [x] make check passes (lint + typecheck + tests)
- [x] New/updated tests for the changes
- [x] No unrelated changes included