### PR TITLE
fix: PIDs panel checkboxes not showing supported status

### DIFF
--- a/odb_tui/services/connection.py
+++ b/odb_tui/services/connection.py
@@ -49,6 +49,7 @@ class OBDConnectionService:
         if not self.is_connected or self.connection is None:
             return SupportedCommands()
 
+        supported_names: set[str] = {str(c.name) for c in self.connection.supported_commands}
         modes: dict[str, list[CommandStatus]] = {}
 
         for mode_num in (1, 2, 3, 4, 6, 7, 9):
@@ -62,7 +63,7 @@ class OBDConnectionService:
                 if cmd is None:
                     continue
                 pid_hex = f"0x{cmd.pid:02X}" if hasattr(cmd, "pid") and cmd.pid is not None else "-"
-                supported = bool(self.connection.supports(cmd))
+                supported = str(cmd.name) in supported_names
                 cmds.append(CommandStatus(
                     name=str(cmd.name),
                     pid=pid_hex,
@@ -77,7 +78,7 @@ class OBDConnectionService:
         for elm_name in ("ELM_VERSION", "ELM_VOLTAGE"):
             cmd = getattr(obd.commands, elm_name, None)
             if cmd is not None:
-                supported = bool(self.connection.supports(cmd))
+                supported = str(cmd.name) in supported_names
                 elm_cmds.append(CommandStatus(
                     name=str(cmd.name),
                     pid="-",

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -54,7 +54,7 @@ def test_discover_supported_commands(mocker):
     mock_cmd2.desc = "Vehicle Speed"
     mock_conn = MagicMock()
     mock_conn.is_connected.return_value = True
-    mock_conn.supports.side_effect = lambda cmd: cmd.name == "RPM"
+    mock_conn.supported_commands = {mock_cmd1}
     mocker.patch("odb_tui.services.connection.obd.OBD", return_value=mock_conn)
     mocker.patch("odb_tui.services.connection.obd.commands.__getitem__", return_value=[mock_cmd1, mock_cmd2])
     svc = OBDConnectionService()

--- a/tests/test_discover_supported.py
+++ b/tests/test_discover_supported.py
@@ -1,0 +1,42 @@
+from unittest.mock import MagicMock, patch
+
+from odb_tui.services.connection import OBDConnectionService
+
+
+def _make_cmd(name: str, pid: int | None, desc: str) -> MagicMock:
+    cmd = MagicMock()
+    cmd.name = name
+    cmd.pid = pid
+    cmd.desc = desc
+    return cmd
+
+
+def test_discover_marks_supported_by_name():
+    """Regression: supported commands must be detected by name, not object identity."""
+    rpm_in_mode = _make_cmd("RPM", 0x0C, "Engine RPM")
+    speed_in_mode = _make_cmd("SPEED", 0x0D, "Vehicle Speed")
+
+    # Different object instances with the same name — simulates real python-obd behavior
+    rpm_in_supported = _make_cmd("RPM", 0x0C, "Engine RPM")
+
+    conn_mock = MagicMock()
+    conn_mock.is_connected.return_value = True
+    conn_mock.supported_commands = {rpm_in_supported}
+
+    svc = OBDConnectionService()
+    svc.connection = conn_mock
+
+    mock_commands = MagicMock()
+    mock_commands.__getitem__ = MagicMock(side_effect=lambda k: {1: [rpm_in_mode, speed_in_mode]}[k])
+    mock_commands.ELM_VERSION = None
+    mock_commands.ELM_VOLTAGE = None
+
+    with patch("odb_tui.services.connection.obd.commands", mock_commands):
+        result = svc.discover_supported_commands()
+
+    mode_cmds = result.modes["Mode 01 — Live Data"]
+    rpm_status = next(c for c in mode_cmds if c.name == "RPM")
+    speed_status = next(c for c in mode_cmds if c.name == "SPEED")
+
+    assert rpm_status.supported is True
+    assert speed_status.supported is False


### PR DESCRIPTION
## Summary

- Fix supported commands detection to compare by name instead of object identity
- `connection.supports(cmd)` could fail when command objects from `obd.commands[mode]` are different instances than those in `connection.supported_commands`
- Build a `supported_names` set from command names and check membership by name string

Closes #7

## Test plan

- [x] Regression test with different object instances sharing the same name
- [x] `make check` passes (54 tests)