### PR TITLE
feat: remove redundant title lines from panel builders

### DIFF
--- a/odb_tui/views/panels/diag.py
+++ b/odb_tui/views/panels/diag.py
@@ -8,8 +8,7 @@ from odb_tui.views.formatters import add_if, fmt, fmt_str, fmt_time, fmti
 
 def build_diag_panel(state: VehicleState) -> str:
     """Build the diagnostics panel displaying MIL, DTCs, compliance, and counters."""
-    lines: list[str] = ["DIAGNOSTICS"]
-    lines.append("─" * 60)
+    lines: list[str] = []
 
     # Status (MIL, DTC count, ignition type)
     mil_str = "--"

--- a/odb_tui/views/panels/egr.py
+++ b/odb_tui/views/panels/egr.py
@@ -9,8 +9,7 @@ from odb_tui.views.widgets import bar
 
 def build_egr_panel(state: VehicleState) -> str:
     """Build the EGR panel displaying commanded EGR and error interpretation."""
-    lines: list[str] = ["EGR"]
-    lines.append("─" * 60)
+    lines: list[str] = []
 
     if state.egr_cmd is None and state.egr_err is None:
         lines.append("  No EGR data available")

--- a/odb_tui/views/panels/engine.py
+++ b/odb_tui/views/panels/engine.py
@@ -9,8 +9,7 @@ from odb_tui.views.widgets import bar
 
 def build_engine_panel(state: VehicleState) -> str:
     """Build the engine panel displaying RPM, load, temps, fuel, and O2 data."""
-    lines: list[str] = ["ENGINE"]
-    lines.append("─" * 60)
+    lines: list[str] = []
 
     add_if(lines, "RPM", state.rpm, fmti, bar, 7000)
     add_if(lines, "LOAD %", state.engine_load, fmt, bar, 100)

--- a/odb_tui/views/panels/errors.py
+++ b/odb_tui/views/panels/errors.py
@@ -7,8 +7,7 @@ from odb_tui.models.vehicle import VehicleState
 
 def build_errors_panel(state: VehicleState) -> str:
     """Build the errors panel displaying active DTCs."""
-    lines: list[str] = ["ERRORS"]
-    lines.append("─" * 60)
+    lines: list[str] = []
 
     if state.connection_status in ("DISCONNECTED", "NO DEVICE", "FAILED"):
         lines.append("  --")

--- a/odb_tui/views/panels/pids.py
+++ b/odb_tui/views/panels/pids.py
@@ -11,7 +11,6 @@ def build_pids_panel(supported_commands: SupportedCommands | None) -> str:
         return "Not connected"
 
     lines: list[str] = []
-    lines.append("SUPPORTED OBD COMMANDS")
     lines.append(f"  Total: {supported_commands.supported_count} / {supported_commands.total} supported")
     lines.append("")
 

--- a/odb_tui/views/panels/turbo.py
+++ b/odb_tui/views/panels/turbo.py
@@ -9,8 +9,7 @@ from odb_tui.views.widgets import bar
 
 def build_turbo_panel(state: VehicleState) -> str:
     """Build the turbo panel displaying pressure, boost, throttle, and accelerator data."""
-    lines: list[str] = ["TURBO / AIR"]
-    lines.append("─" * 60)
+    lines: list[str] = []
 
     add_if(lines, "INTAKE kPa", state.intake_press, fmt, bar, 300)
     add_if(lines, "BARO kPa", state.baro, fmt)

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -5,7 +5,6 @@ from odb_tui.views.panels.engine import build_engine_panel
 from odb_tui.views.panels.errors import build_errors_panel
 from odb_tui.views.panels.turbo import build_turbo_panel
 
-
 # --- Engine panel ---
 
 

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -6,9 +6,21 @@ from odb_tui.views.panels.errors import build_errors_panel
 from odb_tui.views.panels.turbo import build_turbo_panel
 
 
-def test_engine_panel_empty_state():
+# --- Engine panel ---
+
+
+def test_engine_panel_no_title():
     result = build_engine_panel(VehicleState())
-    assert "ENGINE" in result
+    first_line = result.split("\n")[0]
+    assert first_line != "ENGINE"
+
+
+def test_engine_panel_no_title_separator():
+    result = build_engine_panel(VehicleState())
+    lines = result.split("\n")
+    assert lines[0] != "─" * 60
+    if len(lines) > 1:
+        assert lines[1] != "─" * 60
 
 
 def test_engine_panel_with_data():
@@ -19,9 +31,39 @@ def test_engine_panel_with_data():
     assert "LEVEL" in result
 
 
-def test_turbo_panel_empty_state():
+def test_engine_panel_temperatures_subsection():
+    state = VehicleState(coolant_temp=90.0)
+    result = build_engine_panel(state)
+    assert "TEMPERATURES" in result
+
+
+def test_engine_panel_fuel_subsection():
+    state = VehicleState(fuel_level=75.0)
+    result = build_engine_panel(state)
+    assert "FUEL" in result
+
+
+def test_engine_panel_o2_subsection():
+    state = VehicleState(o2_s1_wr=1.0)
+    result = build_engine_panel(state)
+    assert "O2 SENSORS" in result
+
+
+# --- Turbo panel ---
+
+
+def test_turbo_panel_no_title():
     result = build_turbo_panel(VehicleState())
-    assert "TURBO" in result
+    first_line = result.split("\n")[0]
+    assert first_line != "TURBO / AIR"
+
+
+def test_turbo_panel_no_title_separator():
+    result = build_turbo_panel(VehicleState())
+    lines = result.split("\n")
+    assert lines[0] != "─" * 60
+    if len(lines) > 1:
+        assert lines[1] != "─" * 60
 
 
 def test_turbo_panel_with_boost():
@@ -31,10 +73,33 @@ def test_turbo_panel_with_boost():
     assert "NET BOOST" in result
 
 
-def test_egr_panel_empty_state():
+def test_turbo_panel_throttle_subsection():
+    state = VehicleState(throttle=50.0)
+    result = build_turbo_panel(state)
+    assert "THROTTLE" in result
+
+
+def test_turbo_panel_accelerator_subsection():
+    state = VehicleState(accel_d=30.0)
+    result = build_turbo_panel(state)
+    assert "ACCELERATOR" in result
+
+
+# --- EGR panel ---
+
+
+def test_egr_panel_no_title():
     result = build_egr_panel(VehicleState())
-    assert "EGR" in result
-    assert "No EGR data" in result
+    first_line = result.split("\n")[0]
+    assert first_line != "EGR"
+
+
+def test_egr_panel_no_title_separator():
+    result = build_egr_panel(VehicleState())
+    lines = result.split("\n")
+    assert lines[0] != "─" * 60
+    if len(lines) > 1:
+        assert lines[1] != "─" * 60
 
 
 def test_egr_panel_with_data():
@@ -44,9 +109,25 @@ def test_egr_panel_with_data():
     assert "3.5% below" in result
 
 
-def test_diag_panel_empty_state():
+# --- Diag panel ---
+
+
+def test_diag_panel_no_title():
     result = build_diag_panel(VehicleState())
-    assert "DIAGNOSTICS" in result
+    first_line = result.split("\n")[0]
+    assert first_line != "DIAGNOSTICS"
+
+
+def test_diag_panel_no_title_separator():
+    result = build_diag_panel(VehicleState())
+    lines = result.split("\n")
+    assert lines[0] != "─" * 60
+    if len(lines) > 1:
+        assert lines[1] != "─" * 60
+
+
+def test_diag_panel_mil_present():
+    result = build_diag_panel(VehicleState())
     assert "MIL" in result
 
 
@@ -55,6 +136,49 @@ def test_diag_panel_with_dtcs():
     result = build_diag_panel(state)
     assert "P0420" in result
     assert "Catalyst" in result
+
+
+def test_diag_panel_counters_subsection():
+    state = VehicleState(dist_mil=100.0)
+    result = build_diag_panel(state)
+    assert "COUNTERS" in result
+
+
+def test_diag_panel_calibration_subsection():
+    state = VehicleState(cal_id="CAL123")
+    result = build_diag_panel(state)
+    assert "CALIBRATION" in result
+
+
+def test_diag_panel_stored_dtcs_subsection():
+    state = VehicleState(dtc_list=[("P0420", "Catalyst efficiency")])
+    result = build_diag_panel(state)
+    assert "STORED DTCs" in result
+
+
+def test_diag_panel_current_dtcs_subsection():
+    state = VehicleState(current_dtc_list=[("P0300", "Random misfire")])
+    result = build_diag_panel(state)
+    assert "CURRENT DTCs" in result
+
+
+# --- Errors panel ---
+
+
+def test_errors_panel_no_title():
+    state = VehicleState(connection_status="CONNECTED")
+    result = build_errors_panel(state)
+    first_line = result.split("\n")[0]
+    assert first_line != "ERRORS"
+
+
+def test_errors_panel_no_title_separator():
+    state = VehicleState(connection_status="CONNECTED")
+    result = build_errors_panel(state)
+    lines = result.split("\n")
+    assert lines[0] != "─" * 60
+    if len(lines) > 1:
+        assert lines[1] != "─" * 60
 
 
 def test_errors_panel_not_connected():

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -9,12 +9,14 @@ from odb_tui.views.panels.turbo import build_turbo_panel
 
 
 def test_engine_panel_no_title():
+    """Verify engine panel output does not start with a title line."""
     result = build_engine_panel(VehicleState())
     first_line = result.split("\n")[0]
     assert first_line != "ENGINE"
 
 
 def test_engine_panel_no_title_separator():
+    """Verify engine panel does not begin with a separator line."""
     result = build_engine_panel(VehicleState())
     lines = result.split("\n")
     assert lines[0] != "─" * 60
@@ -31,18 +33,21 @@ def test_engine_panel_with_data():
 
 
 def test_engine_panel_temperatures_subsection():
+    """Verify temperatures subsection appears when temperature data is present."""
     state = VehicleState(coolant_temp=90.0)
     result = build_engine_panel(state)
     assert "TEMPERATURES" in result
 
 
 def test_engine_panel_fuel_subsection():
+    """Verify fuel subsection appears when fuel data is present."""
     state = VehicleState(fuel_level=75.0)
     result = build_engine_panel(state)
     assert "FUEL" in result
 
 
 def test_engine_panel_o2_subsection():
+    """Verify O2 sensors subsection appears when O2 data is present."""
     state = VehicleState(o2_s1_wr=1.0)
     result = build_engine_panel(state)
     assert "O2 SENSORS" in result
@@ -52,12 +57,14 @@ def test_engine_panel_o2_subsection():
 
 
 def test_turbo_panel_no_title():
+    """Verify turbo panel output does not start with a title line."""
     result = build_turbo_panel(VehicleState())
     first_line = result.split("\n")[0]
     assert first_line != "TURBO / AIR"
 
 
 def test_turbo_panel_no_title_separator():
+    """Verify turbo panel does not begin with a separator line."""
     result = build_turbo_panel(VehicleState())
     lines = result.split("\n")
     assert lines[0] != "─" * 60
@@ -73,12 +80,14 @@ def test_turbo_panel_with_boost():
 
 
 def test_turbo_panel_throttle_subsection():
+    """Verify throttle subsection appears when throttle data is present."""
     state = VehicleState(throttle=50.0)
     result = build_turbo_panel(state)
     assert "THROTTLE" in result
 
 
 def test_turbo_panel_accelerator_subsection():
+    """Verify accelerator subsection appears when accelerator data is present."""
     state = VehicleState(accel_d=30.0)
     result = build_turbo_panel(state)
     assert "ACCELERATOR" in result
@@ -88,12 +97,14 @@ def test_turbo_panel_accelerator_subsection():
 
 
 def test_egr_panel_no_title():
+    """Verify EGR panel output does not start with a title line."""
     result = build_egr_panel(VehicleState())
     first_line = result.split("\n")[0]
     assert first_line != "EGR"
 
 
 def test_egr_panel_no_title_separator():
+    """Verify EGR panel does not begin with a separator line."""
     result = build_egr_panel(VehicleState())
     lines = result.split("\n")
     assert lines[0] != "─" * 60
@@ -112,12 +123,14 @@ def test_egr_panel_with_data():
 
 
 def test_diag_panel_no_title():
+    """Verify diagnostics panel output does not start with a title line."""
     result = build_diag_panel(VehicleState())
     first_line = result.split("\n")[0]
     assert first_line != "DIAGNOSTICS"
 
 
 def test_diag_panel_no_title_separator():
+    """Verify diagnostics panel does not begin with a separator line."""
     result = build_diag_panel(VehicleState())
     lines = result.split("\n")
     assert lines[0] != "─" * 60
@@ -126,6 +139,7 @@ def test_diag_panel_no_title_separator():
 
 
 def test_diag_panel_mil_present():
+    """Verify MIL status is always present in diagnostics panel output."""
     result = build_diag_panel(VehicleState())
     assert "MIL" in result
 
@@ -138,24 +152,28 @@ def test_diag_panel_with_dtcs():
 
 
 def test_diag_panel_counters_subsection():
+    """Verify counters subsection appears when counter data is present."""
     state = VehicleState(dist_mil=100.0)
     result = build_diag_panel(state)
     assert "COUNTERS" in result
 
 
 def test_diag_panel_calibration_subsection():
+    """Verify calibration subsection appears when calibration data is present."""
     state = VehicleState(cal_id="CAL123")
     result = build_diag_panel(state)
     assert "CALIBRATION" in result
 
 
 def test_diag_panel_stored_dtcs_subsection():
+    """Verify stored DTCs subsection appears when stored DTCs are present."""
     state = VehicleState(dtc_list=[("P0420", "Catalyst efficiency")])
     result = build_diag_panel(state)
     assert "STORED DTCs" in result
 
 
 def test_diag_panel_current_dtcs_subsection():
+    """Verify current DTCs subsection appears when current DTCs are present."""
     state = VehicleState(current_dtc_list=[("P0300", "Random misfire")])
     result = build_diag_panel(state)
     assert "CURRENT DTCs" in result
@@ -165,6 +183,7 @@ def test_diag_panel_current_dtcs_subsection():
 
 
 def test_errors_panel_no_title():
+    """Verify errors panel output does not start with a title line."""
     state = VehicleState(connection_status="CONNECTED")
     result = build_errors_panel(state)
     first_line = result.split("\n")[0]
@@ -172,6 +191,7 @@ def test_errors_panel_no_title():
 
 
 def test_errors_panel_no_title_separator():
+    """Verify errors panel does not begin with a separator line."""
     state = VehicleState(connection_status="CONNECTED")
     result = build_errors_panel(state)
     lines = result.split("\n")

--- a/tests/test_pids_panel.py
+++ b/tests/test_pids_panel.py
@@ -2,21 +2,31 @@ from odb_tui.models.supported_commands import CommandStatus, SupportedCommands
 from odb_tui.views.panels.pids import build_pids_panel
 
 
-def test_build_pids_panel_not_connected():
-    result = build_pids_panel(None)
-    assert "Not connected" in result
-
-
-def test_build_pids_panel_with_commands():
+def _make_supported_commands() -> SupportedCommands:
     modes = {
         "Mode 01 — Live Data": [
             CommandStatus(name="RPM", pid="0x0C", description="Engine RPM", supported=True),
             CommandStatus(name="SPEED", pid="0x0D", description="Vehicle Speed", supported=False),
         ],
     }
-    sc = SupportedCommands(modes=modes)
+    return SupportedCommands(modes=modes)
+
+
+def test_build_pids_panel_not_connected():
+    result = build_pids_panel(None)
+    assert "Not connected" in result
+
+
+def test_build_pids_panel_no_title():
+    sc = _make_supported_commands()
     result = build_pids_panel(sc)
-    assert "SUPPORTED OBD COMMANDS" in result
+    first_line = result.split("\n")[0]
+    assert first_line != "SUPPORTED OBD COMMANDS"
+
+
+def test_build_pids_panel_with_commands():
+    sc = _make_supported_commands()
+    result = build_pids_panel(sc)
     assert "1 / 2 supported" in result
     assert "Mode 01" in result
     assert "RPM" in result
@@ -24,16 +34,17 @@ def test_build_pids_panel_with_commands():
 
 
 def test_build_pids_panel_checkbox_format():
-    modes = {
-        "Mode 01 — Live Data": [
-            CommandStatus(name="RPM", pid="0x0C", description="Engine RPM", supported=True),
-            CommandStatus(name="EGT", pid="0x78", description="Exhaust Gas Temp", supported=False),
-        ],
-    }
-    sc = SupportedCommands(modes=modes)
+    sc = _make_supported_commands()
     result = build_pids_panel(sc)
     lines = result.split("\n")
     rpm_line = [line for line in lines if "RPM" in line][0]
-    egt_line = [line for line in lines if "EGT" in line][0]
+    egt_lines = [line for line in lines if "SPEED" in line]
+    speed_line = egt_lines[0]
     assert "[x]" in rpm_line
-    assert "[ ]" in egt_line
+    assert "[ ]" in speed_line
+
+
+def test_build_pids_panel_mode_headers_present():
+    sc = _make_supported_commands()
+    result = build_pids_panel(sc)
+    assert "Mode 01 — Live Data" in result

--- a/tests/test_pids_panel.py
+++ b/tests/test_pids_panel.py
@@ -3,6 +3,7 @@ from odb_tui.views.panels.pids import build_pids_panel
 
 
 def _make_supported_commands() -> SupportedCommands:
+    """Create a sample SupportedCommands fixture for testing."""
     modes = {
         "Mode 01 — Live Data": [
             CommandStatus(name="RPM", pid="0x0C", description="Engine RPM", supported=True),
@@ -18,6 +19,7 @@ def test_build_pids_panel_not_connected():
 
 
 def test_build_pids_panel_no_title():
+    """Verify PIDs panel output does not start with a title line."""
     sc = _make_supported_commands()
     result = build_pids_panel(sc)
     first_line = result.split("\n")[0]
@@ -45,6 +47,7 @@ def test_build_pids_panel_checkbox_format():
 
 
 def test_build_pids_panel_mode_headers_present():
+    """Verify mode group headers appear in the PIDs panel output."""
     sc = _make_supported_commands()
     result = build_pids_panel(sc)
     assert "Mode 01 — Live Data" in result


### PR DESCRIPTION
## Summary

Remove redundant title lines from panel builders since TabbedContent tabs already display panel names.

## Related issue

Closes #15

## Models

None

## Services

None

## Controllers

None

## Views

- `views/panels/engine.py`
- `views/panels/turbo.py`
- `views/panels/egr.py`
- `views/panels/diag.py`
- `views/panels/errors.py`
- `views/panels/pids.py`

## Tests

- `tests/test_panels.py`: Updated existing tests and added new tests asserting title lines and separators are NOT in output. Added sub-section title preservation tests (TEMPERATURES, FUEL, O2 SENSORS, THROTTLE, ACCELERATOR, COUNTERS, CALIBRATION, STORED DTCs, CURRENT DTCs).
- `tests/test_pids_panel.py`: Updated tests to assert "SUPPORTED OBD COMMANDS" title is removed. Added mode header preservation test.

## Dependencies

None

## Checklist

- [ ] `make check` passes (lint + typecheck + tests)
- [ ] New/updated tests for the changes
- [ ] No unrelated changes included