### PR TITLE
feat: disable dashboard tabs when device is not connected

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ odb-tui --version
   - **Errors** (5): active diagnostic trouble codes
   - **Supported PIDs** (p): full OBD command list with availability checkboxes
 - Footer displays live connection info: status, port, and device VID:PID
+- Tabs are disabled when no OBD device is connected; they enable on connect and disable again on disconnect
 - Keybindings: `c` connect, `d` disconnect, `1`-`5` switch panels, `p` PIDs, `q` quit
 
 ## Development

--- a/odb_tui/app.py
+++ b/odb_tui/app.py
@@ -110,6 +110,11 @@ class OBDReaderApp(App[None]):
         self._set_tabs_enabled(False)
 
     def _set_tabs_enabled(self, enabled: bool) -> None:
+        """Enable or disable all tabs in the tabbed content.
+
+        Args:
+            enabled: If True, enable all tabs; if False, disable them.
+        """
         for tab in self.query("Tab"):
             tab.disabled = not enabled
 

--- a/odb_tui/app.py
+++ b/odb_tui/app.py
@@ -77,6 +77,7 @@ class OBDReaderApp(App[None]):
     Tabs { background: black; color: green; }
     Tab { background: black; color: green; }
     Tab.-active { background: green; color: black; }
+    Tab.-disabled { color: $text-disabled; opacity: 0.5; }
     """
 
     BINDINGS = [
@@ -106,6 +107,11 @@ class OBDReaderApp(App[None]):
         self._state = VehicleState()
         self._refresh_active_panel()
         self._poll_timer = self.set_interval(1.0, self._poll_sensors, pause=True)
+        self._set_tabs_enabled(False)
+
+    def _set_tabs_enabled(self, enabled: bool) -> None:
+        for tab in self.query("Tab"):
+            tab.disabled = not enabled
 
     def _refresh_status(self) -> None:
         """Update the Footer with connection info."""
@@ -142,6 +148,7 @@ class OBDReaderApp(App[None]):
         self._refresh_status()
         self._refresh_active_panel()
         if self.ctrl.status == "CONNECTED":
+            self._set_tabs_enabled(True)
             self._poll_timer.resume()
 
     async def action_disconnect(self) -> None:
@@ -149,10 +156,13 @@ class OBDReaderApp(App[None]):
         self._poll_timer.pause()
         self.ctrl.disconnect()
         self._state = VehicleState()
+        self._set_tabs_enabled(False)
         self._refresh_status()
         self._refresh_active_panel()
 
     async def action_switch_tab(self, name: str) -> None:
         """Switch to the tab identified by name."""
+        if self.ctrl.status != "CONNECTED":
+            return
         tabs = self.query_one("#tabs", TabbedContent)
         tabs.active = name

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -85,13 +85,18 @@ def _run_async(coro):
 @patch("odb_tui.app.AppController")
 def test_action_switch_tab_sets_active(mock_ctrl_cls):
     """Calling action_switch_tab should set the TabbedContent active tab."""
-    mock_ctrl_cls.return_value = _mock_ctrl()
+    mock_ctrl = _mock_ctrl()
+    mock_ctrl_cls.return_value = mock_ctrl
 
     async def run():
         app = OBDReaderApp()
         async with app.run_test() as pilot:
             from textual.widgets import TabbedContent
 
+            await pilot.pause()
+            mock_ctrl.status = "CONNECTED"
+            await app.action_connect()
+            await pilot.pause()
             await app.action_switch_tab("turbo")
             await pilot.pause()
             tabs = app.query_one("#tabs", TabbedContent)
@@ -103,13 +108,18 @@ def test_action_switch_tab_sets_active(mock_ctrl_cls):
 @patch("odb_tui.app.AppController")
 def test_action_switch_tab_to_each_panel(mock_ctrl_cls):
     """Switching to every tab in TAB_ORDER should activate each one."""
-    mock_ctrl_cls.return_value = _mock_ctrl()
+    mock_ctrl = _mock_ctrl()
+    mock_ctrl_cls.return_value = mock_ctrl
 
     async def run():
         app = OBDReaderApp()
         async with app.run_test() as pilot:
             from textual.widgets import TabbedContent
 
+            await pilot.pause()
+            mock_ctrl.status = "CONNECTED"
+            await app.action_connect()
+            await pilot.pause()
             for tab_id, _ in TAB_ORDER:
                 await app.action_switch_tab(tab_id)
                 await pilot.pause()
@@ -146,7 +156,8 @@ def test_refresh_active_panel_calls_builder_for_engine(mock_ctrl_cls):
 @patch("odb_tui.app.AppController")
 def test_refresh_active_panel_calls_builder_for_turbo(mock_ctrl_cls):
     """Refreshing the active panel on turbo tab should call the turbo builder."""
-    mock_ctrl_cls.return_value = _mock_ctrl()
+    mock_ctrl = _mock_ctrl()
+    mock_ctrl_cls.return_value = mock_ctrl
     mock_builder = MagicMock(return_value="TURBO MOCK")
 
     async def run():
@@ -157,6 +168,10 @@ def test_refresh_active_panel_calls_builder_for_turbo(mock_ctrl_cls):
         try:
             app = OBDReaderApp()
             async with app.run_test() as pilot:
+                await pilot.pause()
+                mock_ctrl.status = "CONNECTED"
+                await app.action_connect()
+                await pilot.pause()
                 await app.action_switch_tab("turbo")
                 await pilot.pause()
                 mock_builder.reset_mock()
@@ -177,6 +192,10 @@ def test_refresh_active_panel_calls_pids_builder(mock_ctrl_cls):
     async def run():
         app = OBDReaderApp()
         async with app.run_test() as pilot:
+            await pilot.pause()
+            mock_ctrl.status = "CONNECTED"
+            await app.action_connect()
+            await pilot.pause()
             await app.action_switch_tab("pids")
             await pilot.pause()
             with patch("odb_tui.app.build_pids_panel", return_value="PIDS MOCK") as mock_pids:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -291,3 +291,98 @@ def test_refresh_status_updates_connection_info(mock_ctrl_cls):
             assert footer is not None
 
     _run_async(run())
+
+
+@patch("odb_tui.app.AppController")
+def test_tabs_disabled_on_startup(mock_ctrl_cls):
+    """All tabs should be disabled on startup when device is not connected."""
+    mock_ctrl_cls.return_value = _mock_ctrl()
+
+    async def run():
+        app = OBDReaderApp()
+        async with app.run_test() as pilot:
+            from textual.widgets import TabbedContent
+
+            await pilot.pause()
+            tabs_widget = app.query_one("#tabs", TabbedContent)
+            for tab_id, _ in TAB_ORDER:
+                tab = tabs_widget.get_tab(tab_id)
+                assert tab.disabled, f"Tab '{tab_id}' should be disabled on startup"
+
+    _run_async(run())
+
+
+@patch("odb_tui.app.AppController")
+def test_tabs_enabled_after_connect(mock_ctrl_cls):
+    """All tabs should be enabled after a successful connection."""
+    mock_ctrl = _mock_ctrl()
+    mock_ctrl_cls.return_value = mock_ctrl
+
+    async def run():
+        app = OBDReaderApp()
+        async with app.run_test() as pilot:
+            from textual.widgets import TabbedContent
+
+            await pilot.pause()
+            mock_ctrl.status = "CONNECTED"
+            await app.action_connect()
+            await pilot.pause()
+            tabs_widget = app.query_one("#tabs", TabbedContent)
+            for tab_id, _ in TAB_ORDER:
+                tab = tabs_widget.get_tab(tab_id)
+                assert not tab.disabled, f"Tab '{tab_id}' should be enabled after connect"
+
+    _run_async(run())
+
+
+@patch("odb_tui.app.AppController")
+def test_tabs_disabled_after_disconnect(mock_ctrl_cls):
+    """All tabs should be disabled again after disconnecting."""
+    mock_ctrl = _mock_ctrl()
+    mock_ctrl_cls.return_value = mock_ctrl
+
+    async def run():
+        app = OBDReaderApp()
+        async with app.run_test() as pilot:
+            from textual.widgets import TabbedContent
+
+            await pilot.pause()
+            mock_ctrl.status = "CONNECTED"
+            await app.action_connect()
+            await pilot.pause()
+            mock_ctrl.status = "DISCONNECTED"
+            await app.action_disconnect()
+            await pilot.pause()
+            tabs_widget = app.query_one("#tabs", TabbedContent)
+            for tab_id, _ in TAB_ORDER:
+                tab = tabs_widget.get_tab(tab_id)
+                assert tab.disabled, f"Tab '{tab_id}' should be disabled after disconnect"
+
+    _run_async(run())
+
+
+@patch("odb_tui.app.AppController")
+def test_action_switch_tab_ignored_when_disconnected(mock_ctrl_cls):
+    """Switching tabs via action_switch_tab should be ignored when disconnected."""
+    mock_ctrl_cls.return_value = _mock_ctrl()
+
+    async def run():
+        app = OBDReaderApp()
+        async with app.run_test() as pilot:
+            from textual.widgets import TabbedContent
+
+            await pilot.pause()
+            tabs_widget = app.query_one("#tabs", TabbedContent)
+            initial_active = tabs_widget.active
+            await app.action_switch_tab("turbo")
+            await pilot.pause()
+            assert tabs_widget.active == initial_active, "Tab should not switch when disconnected"
+
+    _run_async(run())
+
+
+@patch("odb_tui.app.AppController")
+def test_disabled_tabs_have_dimmed_style(mock_ctrl_cls):
+    """Disabled tabs should have a distinct dimmed visual style via CSS."""
+    mock_ctrl_cls.return_value = _mock_ctrl()
+    assert "Tab.-disabled" in OBDReaderApp.CSS or "Tab:disabled" in OBDReaderApp.CSS


### PR DESCRIPTION
## Summary

Disable all dashboard tabs when OBD device is not connected. Enable tabs on connect, disable on disconnect.

## Related issue

Closes #17

## Models

None

## Services

None

## Controllers

None

## Views

- `odb_tui/app.py`

## Documentation

- `README.md` — added tab disable behavior to "What it does" section

## Tests

- [x] `test_tabs_disabled_on_startup` — all tabs disabled on startup
- [x] `test_tabs_enabled_after_connect` — all tabs enabled after connect
- [x] `test_tabs_disabled_after_disconnect` — all tabs disabled after disconnect
- [x] `test_action_switch_tab_ignored_when_disconnected` — tab switching ignored when disconnected
- [x] `test_disabled_tabs_have_dimmed_style` — disabled tabs have distinct CSS style

## Dependencies

None

## Checklist

- [ ] `make check` passes (lint + typecheck + tests)
- [ ] New/updated tests for the changes
- [ ] No unrelated changes included